### PR TITLE
add optional timestamp substraction of the reported latency by the vicon system

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -90,10 +90,16 @@ bool Task::startHook()
 void Task::updateHook()
 {
 	ViconDataStreamSDK::CPP::Result::Enum result = dataStreamClient.GetFrame().Result;
+
 	if(result == ViconDataStreamSDK::CPP::Result::Success)
 	{
 		base::samples::RigidBodyState rbs;
 		rbs.time = base::Time::now();
+
+		if (_substract_reported_latency.value()) {
+			rbs.time = rbs.time - base::Time::fromSeconds(dataStreamClient.GetLatencyTotal().Total);
+		}
+
 		rbs.sourceFrame = _source_frame.get();
 		rbs.targetFrame = _target_frame.get();
 

--- a/vicon.orogen
+++ b/vicon.orogen
@@ -36,6 +36,9 @@ task_context "Task" do
 	property("uncertainty_samples","int", 0)
 	.doc("Number of samples to compute the online data stream covariance. When set to 0, no uncertainty is computed.")
 
+	property("substract_reported_latency", "bool", false)
+	.doc("substract the vicon-reported letency from the local timestamp. This will not include transmission time from vicon to this task, but still have a more exact timestamps.");
+
 	output_port("pose_samples", "/base/samples/RigidBodyState")
 	.doc("Pose of the configured segment.")
 


### PR DESCRIPTION
This still does not take the transmission time from the vicon pc to the pc running this component into account, but the position is still better related to the time when it was seen by the vicon cameras.

I made it optional and set the default to off to make users read the doc before using it. 