### PR TITLE
publish a pose relative to the first pose

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -93,15 +93,17 @@ void Task::updateHook()
 
 	if(result == ViconDataStreamSDK::CPP::Result::Success)
 	{
-		base::samples::RigidBodyState rbs;
+		base::samples::RigidBodyState rbs, rbs_relative;
 		rbs.time = base::Time::now();
 
 		if (_substract_reported_latency.value()) {
 			rbs.time = rbs.time - base::Time::fromSeconds(dataStreamClient.GetLatencyTotal().Total);
 		}
+		rbs_relative.time = rbs.time;
+		rbs_relative.sourceFrame = rbs.sourceFrame = _source_frame.get();
 
-		rbs.sourceFrame = _source_frame.get();
 		rbs.targetFrame = _target_frame.get();
+		rbs_relative.targetFrame = _target_frame_relative.get();
 
 		// Get the segment name
 		std::string SegmentName = dataStreamClient.GetSubjectRootSegmentName(_subject.value()).SegmentName;
@@ -147,10 +149,17 @@ void Task::updateHook()
 			return;
 		}
 
+		if(!start_pose_initialized && inFrame)
+		{
+			start_pose_initialized = true;
+			start_pose_inverse = segment_transform.inverse(Eigen::TransformTraits::Isometry);
+		}
+
 		if (inFrame || !_invalidate_occluded.get())
 		{
 			/** Fill the Rbs transformation **/
 			rbs.setTransform(segment_transform);
+			rbs_relative.setTransform(start_pose_inverse * segment_transform);
 
 			/** Set uncertainty in the rbs **/
 			if (_uncertainty_samples.value() > 0)
@@ -167,11 +176,13 @@ void Task::updateHook()
 		}else
 		{
 			rbs.invalidate();
+			rbs_relative.invalidate();
 		}
 
 		if (inFrame || !_drop_occluded.get())
 		{
 			_pose_samples.write( rbs );
+			_pose_relative.write( rbs_relative);
 		}
 	}
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -45,6 +45,7 @@ Task::Task(std::string const& name)
 bool Task::configureHook()
 {
 	uncertainty.reset(new vicon::ViconUncertainty<Eigen::Matrix4d>(_uncertainty_samples.value()));
+	start_pose_initialized = false;
 	return true;
 }
 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -17,6 +17,9 @@ namespace vicon
 		boost::shared_ptr<vicon::ViconUncertainty <Eigen::Matrix4d> > uncertainty;
 		ViconDataStreamSDK::CPP::Client dataStreamClient;
 
+		Eigen::Affine3d start_pose_inverse;
+		bool start_pose_initialized = false;
+
 	public:
 		Task(std::string const& name = "vicon::Task");
 

--- a/vicon.orogen
+++ b/vicon.orogen
@@ -45,7 +45,7 @@ task_context "Task" do
 	output_port("pose_samples", "/base/samples/RigidBodyState")
 	.doc("Pose of the configured segment.")
 	output_port("pose_relative",  "/base/samples/RigidBodyState")
-	.doc("Pose of the configured segment relative to its first pose. Can be reset using `reset_pose()`")
+	.doc("Pose of the configured segment relative to its first pose. This will be reset by reconfiguring the task.")
 
 	output_port("unlabeled_markers", "/std/vector</base/Vector3d>")
 end

--- a/vicon.orogen
+++ b/vicon.orogen
@@ -23,6 +23,9 @@ task_context "Task" do
 	property("target_frame", "/std/string", "vicon")
 	.doc("Chosen world reference frame.")
 
+	property("target_frame_relative", "/std/string", "vicon_start")
+	.doc("Chosen world reference frame name for the relative pose.")
+
 	property("drop_occluded", "bool", false)
 	.doc("Do not send samples when the segment is occluded.")
 
@@ -41,6 +44,8 @@ task_context "Task" do
 
 	output_port("pose_samples", "/base/samples/RigidBodyState")
 	.doc("Pose of the configured segment.")
+	output_port("pose_relative",  "/base/samples/RigidBodyState")
+	.doc("Pose of the configured segment relative to its first pose. Can be reset using `reset_pose()`")
 
 	output_port("unlabeled_markers", "/std/vector</base/Vector3d>")
 end


### PR DESCRIPTION
As discussed today. I tested this and it works as intended, but I'm open to API changes.

Also, I did not add a `reset()` operation yet (this would only need to set `start_pose_initialized = false`).
It would also be possible to give the `reset` operation an optional parameter, to set a manual start pose.